### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Provide a single GitHub Actions pipeline to build and deploy the repository as a static site to GitHub Pages.
- Ensure the workflow has the minimal permissions and concurrency controls needed to securely and reliably publish the site.

### Description
- Add `.github/workflows/deploy-pages.yml` that triggers on `push` to `main` and on `workflow_dispatch` for manual runs.
- Set workflow-level permissions to `contents: read`, `pages: write`, and `id-token: write` to support Pages deployment and OIDC flows.
- Add a `concurrency` block with `group: pages` and `cancel-in-progress: true` to avoid overlapping deploys.
- Implement a `build` job that checks out the repo, configures Pages, and uploads the repository root as the pages artifact using `actions/checkout@v4`, `actions/configure-pages@v5`, and `actions/upload-pages-artifact@v3`, and a `deploy` job that depends on `build` and deploys to the `github-pages` environment using `actions/deploy-pages@v4`.

### Testing
- Validated the workflow file exists and inspected its contents with `nl -ba .github/workflows/deploy-pages.yml`, which succeeded.
- Recorded the change to the local repository as a local commit, which completed successfully.
- Attempted to push to a remote repository, which failed because no push destination is configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a326ed048321ba9f9ba76db3cf62)