### PR TITLE
docs: add Deployment (GitHub Pages) section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ npm install
 - `tests/app.test.js` – Node-based automated tests.
 - `TASKS.md` – backlog and implementation status.
 
+## Deployment (GitHub Pages)
+
+Every push to the default branch triggers the GitHub Pages deployment workflow at `.github/workflows/deploy-pages.yml`.
+
+### One-time setup
+
+1. In your repository, go to **Settings → Pages**.
+2. Set **Source** to **GitHub Actions**.
+
+### Operational notes
+
+- To trigger a manual redeploy, run the deploy workflow with `workflow_dispatch` from the **Actions** tab.
+- View deployment logs in the relevant **Actions** workflow run and in the **Pages** environment details for that run.
+- For project pages, the expected site URL format is: `https://<org-or-user>.github.io/<repo>/`.
+- The root `index.html` is the published entrypoint, so maintainers should keep root-level static assets deployable.
+
 ## License
 
 MIT


### PR DESCRIPTION
### Motivation

- Provide clear guidance that the repository uses GitHub Actions to publish the site and to document how deployments are triggered. 
- Surface the one-time Pages setup step so new maintainers can enable deployments without guesswork. 
- Explain operational workflows and the published entrypoint requirement to avoid accidental breakage of the deployed site.

### Description

- Added a new `Deployment (GitHub Pages)` section to `README.md` with deployment details. 
- Documented that every push to the default branch triggers the deployment workflow at `.github/workflows/deploy-pages.yml`. 
- Added a one-time setup instruction to set **Settings → Pages → Source** to **GitHub Actions**. 
- Added operational notes covering manual redeploy via `workflow_dispatch`, where to view deployment logs, the expected project Pages URL format, and that root `index.html` is the published entrypoint.

### Testing

- Verified the updated `README.md` content with `nl -ba README.md | sed -n '1,260p'`, which displayed the new section as expected. 
- Checked the repository state with `git status --short` to confirm the working tree reflects the documentation change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a32df7f4832188a1ab259a45c110)