### PR TITLE
Include worksheet parsing and PDF generation inside reader.onload try block

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -136,10 +136,6 @@ function generateCertificate({
       if (!worksheet) {
         throw new Error("No worksheet found in uploaded file.");
       }
-      onLoaded();
-    }
-  };
-
       const { name, units } = parseWorksheet(worksheet);
       const date = dateFactory();
       const docDefinition = createDocDefinition(name, date, units);


### PR DESCRIPTION
### Motivation
- Ensure workbook parsing and PDF generation occur inside the same `try` so runtime errors are caught, `worksheet` is only referenced within its lexical scope, and `onLoaded()` is invoked exactly once per success/error path.

### Description
- Moved `const { name, units } = parseWorksheet(worksheet);`, `const date = dateFactory();`, `const docDefinition = createDocDefinition(name, date, units);`, and `pdfMaker.createPdf(docDefinition).download("Certificate.pdf");` inside the `reader.onload` `try` block after worksheet validation, removed the premature `onLoaded()` call, and kept the `catch (error)` and `reader.onerror` handlers intact.

### Testing
- Ran `npm test` and all automated tests passed (`10/10`); an attempted `npm test -- --runInBand` invocation failed due to the CLI treating the extra flag as a file argument rather than a test runner option.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0aec7e1008321bb60167e4b862c2d)