### PR TITLE
Add runtime guards for missing spreadsheet/PDF dependencies

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -123,6 +123,16 @@ function generateCertificate({
     return;
   }
 
+  if (!xlsx || typeof xlsx.read !== "function") {
+    onError("Spreadsheet parser is unavailable. Please reload the page.");
+    return;
+  }
+
+  if (!pdfMaker || typeof pdfMaker.createPdf !== "function") {
+    onError("PDF generator is unavailable. Please reload the page.");
+    return;
+  }
+
   onLoading();
   const reader = fileReaderFactory();
 
@@ -136,10 +146,6 @@ function generateCertificate({
       if (!worksheet) {
         throw new Error("No worksheet found in uploaded file.");
       }
-      onLoaded();
-    }
-  };
-
       const { name, units } = parseWorksheet(worksheet);
       const date = dateFactory();
       const docDefinition = createDocDefinition(name, date, units);

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -35,6 +35,35 @@ test('generateCertificate alerts when file selection is not a spreadsheet', () =
   assert.deepEqual(alerts, ['Please select a valid .xlsx or .xls file.']);
 });
 
+test('generateCertificate alerts when spreadsheet parser is unavailable', () => {
+  const alerts = [];
+  global.alert = (message) => alerts.push(message);
+
+  generateCertificate({
+    file: new File([''], 'test.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    }),
+    xlsx: undefined,
+  });
+
+  assert.deepEqual(alerts, ['Spreadsheet parser is unavailable. Please reload the page.']);
+});
+
+test('generateCertificate alerts when PDF generator is unavailable', () => {
+  const alerts = [];
+  global.alert = (message) => alerts.push(message);
+
+  generateCertificate({
+    file: new File([''], 'test.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    }),
+    xlsx: { read: () => ({}) },
+    pdfMaker: undefined,
+  });
+
+  assert.deepEqual(alerts, ['PDF generator is unavailable. Please reload the page.']);
+});
+
 test('generateCertificate calls loading callbacks and downloads PDF', () => {
   const file = new File([''], 'test.xlsx', {
     type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
@@ -95,6 +124,8 @@ test('generateCertificate alerts on file-read error', () => {
         this.onerror();
       },
     }),
+    xlsx: { read: () => ({}) },
+    pdfMaker: { createPdf: () => ({ download: () => {} }) },
   });
 
   assert.deepEqual(alerts, ['Error reading file. Please try again.']);


### PR DESCRIPTION
### Motivation

- Prevent runtime crashes and unclear failures when the XLSX parser or pdfMake are not available by failing early with a clear message.
- Surface a user-friendly error if `xlsx.read` or `pdfMaker.createPdf` are not present instead of executing further processing.
- Preserve existing file presence and spreadsheet-type validation behavior and order.

### Description

- Added early guards in `generateCertificate` that call `onError` and return if `xlsx` is missing or `xlsx.read` is not a function with message `"Spreadsheet parser is unavailable. Please reload the page."`.
- Added early guards in `generateCertificate` that call `onError` and return if `pdfMaker` is missing or `pdfMaker.createPdf` is not a function with message `"PDF generator is unavailable. Please reload the page."`.
- Fixed the `reader.onload` control flow so worksheet parsing, PDF creation (`pdfMaker.createPdf`) and error handling are correctly wrapped in the `try/catch` block.
- Added tests: two new tests for missing `xlsx` and missing `pdfMaker`, and updated the file-read error test to inject dependency mocks so it exercises the `reader.onerror` path after the new guards.

### Testing

- Ran the test suite with `npm test`; all tests passed (`12` tests, `0` failures).
- Verified the new tests (`Spreadsheet parser is unavailable` and `PDF generator is unavailable`) pass alongside existing coverage for file validation and error paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0aec899908321a9d9bf0864b30aca)