### PR TITLE
Flatten unit ordered list entries in PDF doc definition

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -30,9 +30,10 @@ function createDocDefinition(name, date, units) {
         margin: [0, 0, 0, 20],
       },
       {
-        ol: units.map((unit) => [
-          { text: `${unit.code} - ${unit.title}`, margin: [0, 5, 0, 5] },
-        ]),
+        ol: units.map((unit) => ({
+          text: `${unit.code} - ${unit.title}`,
+          margin: [0, 5, 0, 5],
+        })),
       },
       {
         text: "CERTIFICATE DETAILS",
@@ -136,10 +137,6 @@ function generateCertificate({
       if (!worksheet) {
         throw new Error("No worksheet found in uploaded file.");
       }
-      onLoaded();
-    }
-  };
-
       const { name, units } = parseWorksheet(worksheet);
       const date = dateFactory();
       const docDefinition = createDocDefinition(name, date, units);

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -207,4 +207,12 @@ test('createDocDefinition builds expected structure', () => {
   assert.equal(docDefinition.content[0].text, 'CERTIFICATE IV IN TRAINING AND ASSESSMENT');
   assert.equal(docDefinition.content[2].text, name);
   assert.equal(docDefinition.content[docDefinition.content.length - 2].text, date);
+
+  const unitsListSection = docDefinition.content.find((section) => Array.isArray(section.ol));
+  assert.ok(unitsListSection);
+  assert.ok(unitsListSection.ol.every((item) => !Array.isArray(item)));
+  assert.deepEqual(unitsListSection.ol, [
+    { text: 'UNIT1 - Unit 1 Title', margin: [0, 5, 0, 5] },
+    { text: 'UNIT2 - Unit 2 Title', margin: [0, 5, 0, 5] },
+  ]);
 });


### PR DESCRIPTION
### Motivation
- pdfMake expects ordered list (`ol`) items as a flat array of item objects, but the code produced nested single-item arrays which could render incorrectly.
- Preserve existing visible output format (`code - title`) and margin styling for each unit line.
- Ensure test-suite asserts the `docDefinition` structure and prevent regressions by verifying `ol` is a flat array.
- Fix a control-flow placement in `generateCertificate` so worksheet parsing and PDF generation remain inside the `try` block and avoid a syntax/runtime issue.

### Description
- Changed `createDocDefinition` in `src/js/app.js` to map units to flat objects: `ol: units.map((unit) => ({ text: `${unit.code} - ${unit.title}`, margin: [0,5,0,5] }))` instead of nested arrays.
- Updated `tests/app.test.js` to assert there is an `ol` section and that `ol.every((item) => !Array.isArray(item))` is true, and to validate the expected list items.
- Adjusted the `reader.onload` block in `src/js/app.js` so parsing (`parseWorksheet`) and PDF creation remain inside the `try` block, resolving a prior syntax error.
- Modified files: `src/js/app.js` and `tests/app.test.js`.

### Testing
- Ran `npm run lint` which completed without errors.
- Ran `npm test` which executed the test suite and all tests passed (10 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0aec9f37c8321af135e68eef6a170)